### PR TITLE
import localizations directly instead of synthetic package

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,3 +1,4 @@
 arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
+synthetic-package: false

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,7 +13,7 @@ import 'package:weechat/pages/settings/config.dart';
 import 'package:weechat/relay/connection.dart';
 import 'package:weechat/relay/connection/status.dart';
 import 'package:weechat/themes.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:weechat/l10n/app_localizations.dart';
 
 void main() async {
   // get platform dispatcher. this needs to be done through the singleton as described on

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:weechat/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_font_icons/flutter_font_icons.dart';
 import 'package:provider/provider.dart';

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -2,7 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_font_icons/flutter_font_icons.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:weechat/l10n/app_localizations.dart';
 import 'package:weechat/pages/settings/config.dart';
 
 class SettingsPage extends StatefulWidget {

--- a/lib/widgets/channel/line_item.dart
+++ b/lib/widgets/channel/line_item.dart
@@ -1,6 +1,6 @@
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:weechat/l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
 import 'package:weechat/pages/settings/config.dart';
 import 'package:weechat/relay/protocol/line_data.dart';

--- a/lib/widgets/channel/urlify.dart
+++ b/lib/widgets/channel/urlify.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:validators/validators.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:weechat/l10n/app_localizations.dart';
 
 bool validUrl(String text) => isURL(
       text,


### PR DESCRIPTION
The synthetic `package:flutter_gen` package has been deprecated, so just import the localizations directly.

https://docs.flutter.dev/release/breaking-changes/flutter-generate-i10n-source