### PR TITLE
l10n: specify the type of the url placeholder

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -28,7 +28,9 @@
   "urlifyCopiedMessage": "In die Zwischenablage kopiert: {url}",
   "@urlifyCopiedMessage": {
     "placeholders": {
-      "url": {}
+      "url": {
+        "type": "String"
+      }
     }
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -28,7 +28,9 @@
   "urlifyCopiedMessage": "Copied to clipboard: {url}",
   "@urlifyCopiedMessage": {
     "placeholders": {
-      "url": {}
+      "url": {
+        "type": "String"
+      }
     }
   }
 }


### PR DESCRIPTION
When unspecified, the type of the url placeholder is inferred as `Object` for the english localization and as `null` for the german localization (for whatever reason). Since the english localization serves as a template for the german localization, these two files have incompatible types, which leads to an error during the build (see below). Thus, simply specify the type as `String` in both files.

> Target gen_localizations failed: Error: The placeholder, url, has its
> "type" resource attribute set to the "null" type in locale "de", but
> it is "Object" in the template placeholder. For compatibility with
> template placeholder, change the "type" attribute to "Object".