### PR TITLE
relay.connection: increase connect timeout to 10s

### DIFF
--- a/lib/relay/connection.dart
+++ b/lib/relay/connection.dart
@@ -84,7 +84,7 @@ class RelayConnection {
         hostName,
         portNumber,
         onBadCertificate: (c) => ignoreInvalidCertificate,
-        timeout: const Duration(seconds: 1),
+        timeout: const Duration(seconds: 10),
       );
       _socketCreated = DateTime.now();
 


### PR DESCRIPTION
The previous value of 1s was too short and sometimes caused connection attempts to be prematurely aborted.